### PR TITLE
fix(tui): Guard against nil job item in onStepChanged

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1494,7 +1494,7 @@ func (m *model) onStepChanged() {
 	step := m.stepsList.SelectedItem()
 	cursor := m.stepsList.Cursor()
 
-	if step == nil {
+	if ji == nil || step == nil {
 		return
 	}
 


### PR DESCRIPTION
getSelectedJobItem() can return nil when no job is selected, but onStepChanged only checked for a nil step, not a nil job item. This caused a nil pointer dereference when iterating ji.logs on line 1506.

Add ji to the existing nil guard so the function returns early when there is no selected job item.

---

I was getting a nil pointer dereference crash when attempting to search then view some jobs. This guard prevents that.