### PR TITLE
feat: support viewing workflow runs without PR context

### DIFF
--- a/cmd/enhance/root.go
+++ b/cmd/enhance/root.go
@@ -28,7 +28,7 @@ var asciiArt string
 var logoWithTagline = lipgloss.NewStyle().Foreground(lipgloss.Green).Render(asciiArt)
 
 var rootCmd = &cobra.Command{
-	Use:   "gh enhance [<PR URL> | <PR number>] [flags]",
+	Use:   "gh enhance [<PR URL> | <run URL> | <number>] [flags]",
 	Long:  logoWithTagline,
 	Short: "A Blazingly Fast Terminal UI for GitHub Actions",
 	Args:  cobra.MinimumNArgs(1),
@@ -37,7 +37,13 @@ var rootCmd = &cobra.Command{
 
  # look up via a PR number when inside a clone of dlvhdr/gh-dash
  # will look at checks of https://github.com/dlvhdr/gh-dash/pull/767
- gh enhance 767`,
+ gh enhance 767
+
+ # look up via a full URL to a GitHub Actions run
+ gh enhance https://github.com/dlvhdr/gh-dash/actions/runs/23687980056
+
+ # look up via a run ID (--run disambiguates from PR numbers)
+ gh enhance 23687980056 --run`,
 }
 
 func Execute() error {
@@ -105,6 +111,12 @@ func init() {
 	)
 
 	rootCmd.Flags().Bool(
+		"run",
+		false,
+		"treat the numeric argument as a workflow run ID instead of a PR number",
+	)
+
+	rootCmd.Flags().Bool(
 		"debug",
 		false,
 		"passing this flag will allow writing debug output to debug.log",
@@ -137,16 +149,27 @@ func init() {
 			fmt.Print(usage)
 			return errors.New("no PR passed")
 		}
+
+		isRunMode := false
+		var runID string
+
 		url, err := url.Parse(args[0])
 		if err == nil && url.Hostname() == "github.com" {
 			parts := strings.Split(url.Path, "/")
-			if len(parts) < 5 {
-				fmt.Print(usage)
-				return errors.New("bad PR passed")
-			}
 
-			repo = parts[1] + "/" + parts[2]
-			number = parts[4]
+			// Detect /owner/repo/actions/runs/{id} URLs
+			if len(parts) >= 5 && parts[3] == "actions" && parts[4] == "runs" && len(parts) >= 6 {
+				repo = parts[1] + "/" + parts[2]
+				runID = parts[5]
+				isRunMode = true
+			} else if len(parts) >= 5 {
+				// Existing PR URL handling: /owner/repo/pull/{number}
+				repo = parts[1] + "/" + parts[2]
+				number = parts[4]
+			} else {
+				fmt.Print(usage)
+				return errors.New("bad URL passed")
+			}
 		}
 
 		if repo == "" {
@@ -156,7 +179,25 @@ func init() {
 			}
 		}
 
-		if number == "" {
+		// Check --run flag for bare numeric IDs
+		runFlag, _ := rootCmd.Flags().GetBool("run")
+		if runFlag {
+			if isRunMode {
+				// Already parsed a run URL, --run flag is redundant but not an error
+			} else if number != "" {
+				// A PR URL was parsed but --run was also passed
+				return errors.New("cannot use --run flag with a PR URL")
+			} else {
+				if _, err := strconv.Atoi(args[0]); err != nil {
+					fmt.Print(usage)
+					return errors.New("run ID is not a number")
+				}
+				runID = args[0]
+				isRunMode = true
+			}
+		}
+
+		if !isRunMode && number == "" {
 			if _, err := strconv.Atoi(args[0]); err != nil {
 				fmt.Print(usage)
 				return errors.New("PR number is not a number")
@@ -170,7 +211,12 @@ func init() {
 			return err
 		}
 
-		p := tea.NewProgram(tui.NewModel(repo, number, tui.ModelOpts{Flat: flat}))
+		opts := tui.ModelOpts{Flat: flat}
+		if isRunMode {
+			opts.RunID = runID
+		}
+
+		p := tea.NewProgram(tui.NewModel(repo, number, opts))
 		if _, err := p.Run(); err != nil {
 			log.Error("failed starting program", "err", err)
 			fmt.Println(err)

--- a/cmd/enhance/root.go
+++ b/cmd/enhance/root.go
@@ -8,8 +8,8 @@ import (
 	slog "log"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -27,11 +27,21 @@ import (
 var asciiArt string
 var logoWithTagline = lipgloss.NewStyle().Foreground(lipgloss.Green).Render(asciiArt)
 
+// Regex patterns for GitHub URL parsing
+var (
+	prURLPattern = regexp.MustCompile(
+		`^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)`,
+	)
+	runURLPattern = regexp.MustCompile(
+		`^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/actions/runs/(?P<runID>\d+)`,
+	)
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "gh enhance [<PR URL> | <run URL> | <number>] [flags]",
 	Long:  logoWithTagline,
 	Short: "A Blazingly Fast Terminal UI for GitHub Actions",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.MinimumNArgs(0),
 	Example: `# look up via a full URL to a GitHub PR
  gh enhance https://github.com/dlvhdr/gh-dash/pull/767
 
@@ -43,7 +53,7 @@ var rootCmd = &cobra.Command{
  gh enhance https://github.com/dlvhdr/gh-dash/actions/runs/23687980056
 
  # look up via a run ID (--run disambiguates from PR numbers)
- gh enhance 23687980056 --run`,
+ gh enhance --run 23687980056`,
 }
 
 func Execute() error {
@@ -110,10 +120,10 @@ func init() {
 		"passing this flag will present checks as a flat list",
 	)
 
-	rootCmd.Flags().Bool(
+	rootCmd.Flags().String(
 		"run",
-		false,
-		"treat the numeric argument as a workflow run ID instead of a PR number",
+		"",
+		"look up a workflow run by its numeric ID",
 	)
 
 	rootCmd.Flags().Bool(
@@ -145,30 +155,54 @@ func init() {
 			" for help and examples.\n")
 
 	rootCmd.RunE = func(_ *cobra.Command, args []string) error {
-		if len(args) == 0 {
+		isRunMode := false
+		var runID string
+
+		// Check --run flag first (string flag takes the run ID directly)
+		runFlagVal, _ := rootCmd.Flags().GetString("run")
+		if runFlagVal != "" {
+			if _, err := strconv.Atoi(runFlagVal); err != nil {
+				fmt.Print(usage)
+				return errors.New("run ID is not a number")
+			}
+			runID = runFlagVal
+			isRunMode = true
+
+			if len(args) > 0 {
+				return errors.New("cannot pass both --run and a positional argument")
+			}
+		}
+
+		if !isRunMode && len(args) == 0 {
 			fmt.Print(usage)
 			return errors.New("no PR passed")
 		}
 
-		isRunMode := false
-		var runID string
-
-		url, err := url.Parse(args[0])
-		if err == nil && url.Hostname() == "github.com" {
-			parts := strings.Split(url.Path, "/")
-
-			// Detect /owner/repo/actions/runs/{id} URLs
-			if len(parts) >= 5 && parts[3] == "actions" && parts[4] == "runs" && len(parts) >= 6 {
-				repo = parts[1] + "/" + parts[2]
-				runID = parts[5]
-				isRunMode = true
-			} else if len(parts) >= 5 {
-				// Existing PR URL handling: /owner/repo/pull/{number}
-				repo = parts[1] + "/" + parts[2]
-				number = parts[4]
+		// Parse positional argument (URL or bare number)
+		if !isRunMode && len(args) > 0 {
+			arg := args[0]
+			u, err := url.Parse(arg)
+			if err == nil && u.Hostname() == "github.com" {
+				if m := runURLPattern.FindStringSubmatch(u.Path); m != nil {
+					repo = m[runURLPattern.SubexpIndex("owner")] + "/" +
+						m[runURLPattern.SubexpIndex("repo")]
+					runID = m[runURLPattern.SubexpIndex("runID")]
+					isRunMode = true
+				} else if m := prURLPattern.FindStringSubmatch(u.Path); m != nil {
+					repo = m[prURLPattern.SubexpIndex("owner")] + "/" +
+						m[prURLPattern.SubexpIndex("repo")]
+					number = m[prURLPattern.SubexpIndex("number")]
+				} else {
+					fmt.Print(usage)
+					return errors.New("bad URL passed")
+				}
 			} else {
-				fmt.Print(usage)
-				return errors.New("bad URL passed")
+				// Bare number — must be a PR number
+				if _, err := strconv.Atoi(arg); err != nil {
+					fmt.Print(usage)
+					return errors.New("PR number is not a number")
+				}
+				number = arg
 			}
 		}
 
@@ -179,31 +213,14 @@ func init() {
 			}
 		}
 
-		// Check --run flag for bare numeric IDs
-		runFlag, _ := rootCmd.Flags().GetBool("run")
-		if runFlag {
-			if isRunMode {
-				// Already parsed a run URL, --run flag is redundant but not an error
-			} else if number != "" {
-				// A PR URL was parsed but --run was also passed
-				return errors.New("cannot use --run flag with a PR URL")
-			} else {
-				if _, err := strconv.Atoi(args[0]); err != nil {
-					fmt.Print(usage)
-					return errors.New("run ID is not a number")
-				}
-				runID = args[0]
-				isRunMode = true
-			}
+		if repo == "" {
+			fmt.Print(usage)
+			return errors.New("could not determine repository; use -R owner/repo")
 		}
 
 		if !isRunMode && number == "" {
-			if _, err := strconv.Atoi(args[0]); err != nil {
-				fmt.Print(usage)
-				return errors.New("PR number is not a number")
-			} else {
-				number = args[0]
-			}
+			fmt.Print(usage)
+			return errors.New("no PR or run ID provided")
 		}
 
 		flat, err := rootCmd.Flags().GetBool("flat")

--- a/internal/api/data.go
+++ b/internal/api/data.go
@@ -465,7 +465,11 @@ type WorkflowRunResponse struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 	RunStartedAt time.Time `json:"run_started_at"`
 	DisplayTitle string    `json:"display_title"`
-	Repository   struct {
+	PullRequests []struct {
+		Number int    `json:"number"`
+		Url    string `json:"url"`
+	} `json:"pull_requests"`
+	Repository struct {
 		FullName string `json:"full_name"`
 	} `json:"repository"`
 }

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -21,6 +21,7 @@ type WorkflowRun struct {
 	Bucket       CheckBucket
 	StartedAt    time.Time
 	RunNumber    int
+	PRNumber     int
 }
 
 type WorkflowJob struct {

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -11,15 +11,16 @@ import (
 // WorkflowRun holds all the the jobs that were part of it
 // It is defined by a workflow file that defines the jobs to run
 type WorkflowRun struct {
-	Id        string
-	Name      string
-	Link      string
-	Workflow  string
-	Event     string
-	Jobs      []WorkflowJob
-	Bucket    CheckBucket
-	StartedAt time.Time
-	RunNumber int
+	Id           string
+	Name         string
+	DisplayTitle string
+	Link         string
+	Workflow     string
+	Event        string
+	Jobs         []WorkflowJob
+	Bucket       CheckBucket
+	StartedAt    time.Time
+	RunNumber    int
 }
 
 type WorkflowJob struct {

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -286,28 +286,33 @@ func makeOpenUrlCmd(url string) tea.Cmd {
 	}
 }
 
-func (m *model) makeInitCmd() tea.Cmd {
-	return tea.Batch(
+func (m *model) startSpinners() []tea.Cmd {
+	return []tea.Cmd{
 		m.checksList.StartSpinner(),
 		m.runsList.StartSpinner(),
 		m.logsSpinner.Tick,
 		m.jobsList.StartSpinner(),
+	}
+}
+
+func (m *model) makeInitCmd() tea.Cmd {
+	cmds := m.startSpinners()
+	cmds = append(cmds,
 		m.makeFetchPRCmd(),
 		m.makeInitialGetPRChecksCmd(m.prNumber),
 		m.startFetchingPRChecksWithInterval(),
 	)
+	return tea.Batch(cmds...)
 }
 
 // Run mode: fetch the workflow run and its jobs directly via REST API.
 func (m *model) makeRunModeInitCmd() tea.Cmd {
-	return tea.Batch(
-		m.checksList.StartSpinner(),
-		m.runsList.StartSpinner(),
-		m.logsSpinner.Tick,
-		m.jobsList.StartSpinner(),
+	cmds := m.startSpinners()
+	cmds = append(cmds,
 		m.makeFetchRunCmd(),
 		m.startFetchingRunWithInterval(),
 	)
+	return tea.Batch(cmds...)
 }
 
 type runModeFetchedMsg struct {
@@ -334,7 +339,7 @@ func (m *model) fetchRun() tea.Msg {
 		return runModeFetchedMsg{err: err}
 	}
 
-	run := convertActionsRunToWorkflowRun(runResp, jobsResp)
+	run := convertRunResponseToWorkflowRun(runResp, jobsResp)
 	return runModeFetchedMsg{runs: []data.WorkflowRun{run}}
 }
 
@@ -350,7 +355,7 @@ func (m *model) fetchRunWithInterval() tea.Cmd {
 	return tea.Batch(
 		m.makeFetchRunCmd(),
 		tea.Tick(refreshInterval, func(t time.Time) tea.Msg {
-			if !m.isRunInProgress() {
+			if !m.isRunModeInProgress() {
 				log.Info("run has concluded - not refetching anymore")
 				return nil
 			}
@@ -369,9 +374,9 @@ type runModeIntervalTickMsg struct {
 	msg tea.Msg
 }
 
-func convertActionsRunToWorkflowRun(
-	run api.ActionsRunResponse,
-	jobsResp api.ActionsRunJobsResponse,
+func convertRunResponseToWorkflowRun(
+	run api.WorkflowRunResponse,
+	jobsResp api.WorkflowRunJobsResponse,
 ) data.WorkflowRun {
 	jobs := make([]data.WorkflowJob, 0, len(jobsResp.Jobs))
 	for _, j := range jobsResp.Jobs {
@@ -411,15 +416,16 @@ func convertActionsRunToWorkflowRun(
 
 	runConclusion := api.Conclusion(strings.ToUpper(run.Conclusion))
 	wfRun := data.WorkflowRun{
-		Id:        fmt.Sprintf("%d", run.Id),
-		Name:      run.Name,
-		Link:      run.HtmlUrl,
-		Workflow:  run.Name,
-		Event:     run.Event,
-		Jobs:      jobs,
-		Bucket:    data.GetConclusionBucket(runConclusion),
-		StartedAt: run.RunStartedAt,
-		RunNumber: run.RunNumber,
+		Id:           fmt.Sprintf("%d", run.Id),
+		Name:         run.Name,
+		DisplayTitle: run.DisplayTitle,
+		Link:         run.HtmlUrl,
+		Workflow:     run.Name,
+		Event:        run.Event,
+		Jobs:         jobs,
+		Bucket:       data.GetConclusionBucket(runConclusion),
+		StartedAt:    run.RunStartedAt,
+		RunNumber:    run.RunNumber,
 	}
 
 	return wfRun

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -415,6 +415,12 @@ func convertRunResponseToWorkflowRun(
 	data.SortJobs(jobs)
 
 	runConclusion := api.Conclusion(strings.ToUpper(run.Conclusion))
+
+	var prNumber int
+	if len(run.PullRequests) > 0 {
+		prNumber = run.PullRequests[0].Number
+	}
+
 	wfRun := data.WorkflowRun{
 		Id:           fmt.Sprintf("%d", run.Id),
 		Name:         run.Name,
@@ -426,6 +432,7 @@ func convertRunResponseToWorkflowRun(
 		Bucket:       data.GetConclusionBucket(runConclusion),
 		StartedAt:    run.RunStartedAt,
 		RunNumber:    run.RunNumber,
+		PRNumber:     prNumber,
 	}
 
 	return wfRun

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -298,6 +298,133 @@ func (m *model) makeInitCmd() tea.Cmd {
 	)
 }
 
+// Run mode: fetch the workflow run and its jobs directly via REST API.
+func (m *model) makeRunModeInitCmd() tea.Cmd {
+	return tea.Batch(
+		m.checksList.StartSpinner(),
+		m.runsList.StartSpinner(),
+		m.logsSpinner.Tick,
+		m.jobsList.StartSpinner(),
+		m.makeFetchRunCmd(),
+		m.startFetchingRunWithInterval(),
+	)
+}
+
+type runModeFetchedMsg struct {
+	runs []data.WorkflowRun
+	err  error
+}
+
+func (m *model) makeFetchRunCmd() tea.Cmd {
+	return func() tea.Msg {
+		return m.fetchRun()
+	}
+}
+
+func (m *model) fetchRun() tea.Msg {
+	runResp, err := api.FetchWorkflowRunByID(m.repo, m.runID)
+	if err != nil {
+		log.Error("error fetching workflow run", "err", err)
+		return runModeFetchedMsg{err: err}
+	}
+
+	jobsResp, err := api.FetchWorkflowRunJobs(m.repo, m.runID)
+	if err != nil {
+		log.Error("error fetching workflow run jobs", "err", err)
+		return runModeFetchedMsg{err: err}
+	}
+
+	run := convertActionsRunToWorkflowRun(runResp, jobsResp)
+	return runModeFetchedMsg{runs: []data.WorkflowRun{run}}
+}
+
+func (m *model) startFetchingRunWithInterval() tea.Cmd {
+	return tea.Tick(refreshInterval, func(t time.Time) tea.Msg {
+		return startRunIntervalFetching{}
+	})
+}
+
+type startRunIntervalFetching struct{}
+
+func (m *model) fetchRunWithInterval() tea.Cmd {
+	return tea.Batch(
+		m.makeFetchRunCmd(),
+		tea.Tick(refreshInterval, func(t time.Time) tea.Msg {
+			if !m.isRunInProgress() {
+				log.Info("run has concluded - not refetching anymore")
+				return nil
+			}
+
+			if m.rateLimit.Remaining == 0 && time.Now().Before(m.rateLimit.ResetAt) {
+				log.Warn("rate limit reached, waiting", "m.rateLimit", m.rateLimit)
+				return nil
+			}
+
+			return runModeIntervalTickMsg{msg: m.fetchRun()}
+		}),
+	)
+}
+
+type runModeIntervalTickMsg struct {
+	msg tea.Msg
+}
+
+func convertActionsRunToWorkflowRun(
+	run api.ActionsRunResponse,
+	jobsResp api.ActionsRunJobsResponse,
+) data.WorkflowRun {
+	jobs := make([]data.WorkflowJob, 0, len(jobsResp.Jobs))
+	for _, j := range jobsResp.Jobs {
+		conclusion := api.Conclusion(strings.ToUpper(j.Conclusion))
+		status := api.Status(strings.ToUpper(j.Status))
+
+		steps := make([]api.Step, 0, len(j.Steps))
+		for _, s := range j.Steps {
+			steps = append(steps, api.Step{
+				Conclusion:  api.Conclusion(strings.ToUpper(s.Conclusion)),
+				Name:        s.Name,
+				Number:      s.Number,
+				StartedAt:   s.StartedAt,
+				CompletedAt: s.CompletedAt,
+				Status:      api.Status(strings.ToUpper(s.Status)),
+			})
+		}
+
+		jobs = append(jobs, data.WorkflowJob{
+			Id:          fmt.Sprintf("%d", j.Id),
+			State:       status,
+			Conclusion:  conclusion,
+			Name:        j.Name,
+			Workflow:    run.Name,
+			Event:       run.Event,
+			Logs:        []data.LogsWithTime{},
+			Link:        j.HtmlUrl,
+			Steps:       steps,
+			StartedAt:   j.StartedAt,
+			CompletedAt: j.CompletedAt,
+			Bucket:      data.GetConclusionBucket(conclusion),
+			Kind:        data.JobKindGithubActions,
+			RunNumber:   run.RunNumber,
+		})
+	}
+	data.SortJobs(jobs)
+
+	runConclusion := api.Conclusion(strings.ToUpper(run.Conclusion))
+	wfRun := data.WorkflowRun{
+		Id:        fmt.Sprintf("%d", run.Id),
+		Name:      run.Name,
+		Link:      run.HtmlUrl,
+		Workflow:  run.Name,
+		Event:     run.Event,
+		Jobs:      jobs,
+		Bucket:    data.GetConclusionBucket(runConclusion),
+		StartedAt: run.RunStartedAt,
+		RunNumber: run.RunNumber,
+	}
+
+	return wfRun
+}
+
 func workflowName(cr api.CheckRun) string {
 	wfName := ""
 	wfr := cr.CheckSuite.WorkflowRun

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -915,6 +915,7 @@ func (m *model) viewRunModeHeader(bgStyle lipgloss.Style, logo string, logoWidth
 		lipgloss.NewStyle().Foreground(m.styles.colors.darkerColor), statusColor)
 
 	repoName := bgStyle.Foreground(m.styles.colors.darkColor).Bold(true).Render(m.repo)
+	separator := bgStyle.Foreground(m.styles.colors.faintColor).Render(" ⋅ ")
 	runIdText := bgStyle.Foreground(m.styles.colors.faintColor).Render(
 		fmt.Sprintf("run #%s", m.runID))
 
@@ -922,11 +923,15 @@ func (m *model) viewRunModeHeader(bgStyle lipgloss.Style, logo string, logoWidth
 		bgStyle.Render(status),
 		bgStyle.Render(" "),
 		repoName,
-		bgStyle.Render(" "),
+		separator,
 		runIdText,
 	))
 
-	bottomLine := bgStyle.Width(contentWidth).Bold(true).Render(run.Name)
+	titleText := run.DisplayTitle
+	if titleText == "" {
+		titleText = run.Name
+	}
+	bottomLine := bgStyle.Width(contentWidth).Bold(true).Render(titleText)
 
 	title := bgStyle.Width(contentWidth).Render(lipgloss.JoinVertical(lipgloss.Left,
 		topLine,
@@ -964,46 +969,13 @@ func (m *model) viewFooter() string {
 		contexts.StatusContextCountsByState,
 	)
 
-	if stats.Failed > 0 {
-		texts = append(texts, bg.Foreground(m.styles.colors.errorColor).Render(
-			fmt.Sprintf("%d failing", stats.Failed)))
-	}
-	if stats.InProgress > 0 {
-		texts = append(texts, bg.Foreground(m.styles.colors.warnColor).Render(
-			fmt.Sprintf("%d in progress", stats.InProgress)))
-	}
-	if stats.Succeeded > 0 {
-		texts = append(texts, bg.Foreground(m.styles.colors.successColor).Render(
-			fmt.Sprintf("%d successful", stats.Succeeded)))
-	}
-	if stats.Skipped > 0 {
-		texts = append(texts, bg.Foreground(m.styles.colors.faintColor).Render(
-			fmt.Sprintf("%d skipped", stats.Skipped)))
-	}
+	texts = m.appendStatTexts(
+		texts, bg, stats.Failed, stats.InProgress, stats.Succeeded, stats.Skipped,
+	)
+	checksText := bg.Render(strings.Join(texts, bg.Render(", ")))
 
-	checks := bg.Render(strings.Join(texts, bg.Render(", ")))
-
-	reFetchingIn := ""
-	if m.prWithChecks.Number != 0 && m.prWithChecks.IsStatusCheckInProgress() {
-		until := time.Until(m.lastFetched.Add(refreshInterval)).Truncate(time.Second).Seconds()
-		untilStr := fmt.Sprintf("in %ds", int(until))
-		if until <= 0 {
-			untilStr = "now..."
-		}
-		reFetchingIn = bg.Padding(0, 1).
-			Foreground(m.styles.colors.faintColor).
-			Render(fmt.Sprintf("refreshing %s", untilStr))
-	}
-
-	help := m.styles.helpButtonStyle.Render("? help")
-
-	gap := bg.Render(
-		strings.Repeat(" ", max(0, m.width-lipgloss.Width(totalText)-lipgloss.Width(checks)-
-			lipgloss.Width(reFetchingIn)-lipgloss.Width(help)-
-			m.styles.footerStyle.GetHorizontalFrameSize())))
-
-	return sFooter.Render(
-		lipgloss.JoinHorizontal(lipgloss.Top, totalText, checks, gap, reFetchingIn, help))
+	isInProgress := m.prWithChecks.Number != 0 && m.prWithChecks.IsStatusCheckInProgress()
+	return m.renderFooterLayout(bg, sFooter, totalText, checksText, isInProgress)
 }
 
 func (m *model) viewRunModeFooter(bg lipgloss.Style, sFooter lipgloss.Style) string {
@@ -1035,6 +1007,16 @@ func (m *model) viewRunModeFooter(bg lipgloss.Style, sFooter lipgloss.Style) str
 		}
 	}
 
+	texts = m.appendStatTexts(texts, bg, failed, inProgress, succeeded, skipped)
+	checksText := bg.Render(strings.Join(texts, bg.Render(", ")))
+
+	return m.renderFooterLayout(bg, sFooter, totalText, checksText, m.isRunModeInProgress())
+}
+
+func (m *model) appendStatTexts(
+	texts []string, bg lipgloss.Style,
+	failed, inProgress, succeeded, skipped int,
+) []string {
 	if failed > 0 {
 		texts = append(texts, bg.Foreground(m.styles.colors.errorColor).Render(
 			fmt.Sprintf("%d failing", failed)))
@@ -1051,11 +1033,16 @@ func (m *model) viewRunModeFooter(bg lipgloss.Style, sFooter lipgloss.Style) str
 		texts = append(texts, bg.Foreground(m.styles.colors.faintColor).Render(
 			fmt.Sprintf("%d skipped", skipped)))
 	}
+	return texts
+}
 
-	checksText := bg.Render(strings.Join(texts, bg.Render(", ")))
-
+func (m *model) renderFooterLayout(
+	bg, sFooter lipgloss.Style,
+	totalText, checksText string,
+	isInProgress bool,
+) string {
 	reFetchingIn := ""
-	if m.isRunInProgress() {
+	if isInProgress {
 		until := time.Until(m.lastFetched.Add(refreshInterval)).Truncate(time.Second).Seconds()
 		untilStr := fmt.Sprintf("in %ds", int(until))
 		if until <= 0 {
@@ -1077,7 +1064,7 @@ func (m *model) viewRunModeFooter(bg lipgloss.Style, sFooter lipgloss.Style) str
 		lipgloss.JoinHorizontal(lipgloss.Top, totalText, checksText, gap, reFetchingIn, help))
 }
 
-func (m *model) isRunInProgress() bool {
+func (m *model) isRunModeInProgress() bool {
 	if len(m.workflowRuns) == 0 {
 		return true
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"image/color"
 	"math"
 	"os"
 	"regexp"
@@ -50,6 +51,7 @@ type model struct {
 	height            int
 	prNumber          string
 	repo              string
+	runID             string // set when viewing a run directly (no PR)
 	pr                api.PR
 	prWithChecks      api.PRWithChecks
 	workflowRuns      []data.WorkflowRun
@@ -81,7 +83,8 @@ type model struct {
 }
 
 type ModelOpts struct {
-	Flat bool
+	Flat  bool
+	RunID string // non-empty when in run mode (no PR context)
 }
 
 func NewModel(repo string, number string, opts ModelOpts) model {
@@ -189,6 +192,7 @@ func NewModel(repo string, number string, opts ModelOpts) model {
 		checksList:        checksList,
 		prNumber:          number,
 		repo:              repo,
+		runID:             opts.RunID,
 		runsDelegate:      runsDelegate,
 		jobsDelegate:      jobsDelegate,
 		stepsDelegate:     stepsDelegate,
@@ -211,6 +215,9 @@ func NewModel(repo string, number string, opts ModelOpts) model {
 }
 
 func (m model) Init() tea.Cmd {
+	if m.runID != "" {
+		return m.makeRunModeInitCmd()
+	}
 	return m.makeInitCmd()
 }
 
@@ -233,6 +240,31 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// at the `m.makeInitCmd`. The up to date model is received by this `Update` func.
 	case startIntervalFetching:
 		cmds = append(cmds, m.fetchPRChecksWithInterval())
+
+	case startRunIntervalFetching:
+		cmds = append(cmds, m.fetchRunWithInterval())
+
+	case runModeFetchedMsg, runModeIntervalTickMsg:
+		var rmMsg runModeFetchedMsg
+		if tickMsg, ok := msg.(runModeIntervalTickMsg); ok {
+			rmMsg = tickMsg.msg.(runModeFetchedMsg)
+		} else {
+			rmMsg = msg.(runModeFetchedMsg)
+		}
+
+		if rmMsg.err != nil {
+			log.Debug("error when fetching run", "err", rmMsg.err)
+			m.err = rmMsg.err
+			msgCmd := tea.Printf("%s\nrepo=%s, runID=%s\nOriginal error: %v\n",
+				lipgloss.NewStyle().Foreground(m.styles.colors.errorColor).Bold(true).Render(
+					"❌ Workflow run not found."), m.repo, m.runID, rmMsg.err)
+			return m, tea.Sequence(msgCmd, tea.Quit)
+		}
+
+		m.workflowRuns = rmMsg.runs
+		m.lastFetched = time.Now()
+		m.stopSpinners()
+		cmds = append(cmds, m.onWorkflowRunsFetched()...)
 
 	case prFetchedMsg:
 		m.pr = msg.pr
@@ -785,6 +817,10 @@ func (m *model) viewHeader() string {
 				m.styles.faintFgStyle.Render(version),
 			)))
 
+	if m.runID != "" {
+		return m.viewRunModeHeader(bgStyle, logo, logoWidth)
+	}
+
 	status := bgStyle.Render(m.viewCommitStatus(bgStyle))
 	prWidth := m.width - lipgloss.Width(status) - logoWidth -
 		m.styles.headerStyle.GetHorizontalFrameSize()
@@ -842,9 +878,72 @@ func (m *model) viewPRName(width int, bgStyle lipgloss.Style) string {
 	return bgStyle.Width(width).Bold(true).Render(m.pr.Title)
 }
 
+func (m *model) viewRunModeHeader(bgStyle lipgloss.Style, logo string, logoWidth int) string {
+	contentWidth := m.width - logoWidth - m.styles.headerStyle.GetHorizontalFrameSize()
+
+	if len(m.workflowRuns) == 0 {
+		title := bgStyle.Width(contentWidth).
+			Render(fmt.Sprintf("Loading %s run #%s...", m.repo, m.runID))
+		return m.styles.headerStyle.Width(m.width).Render(
+			lipgloss.JoinHorizontal(lipgloss.Left, bgStyle.Render(title), logo))
+	}
+
+	run := m.workflowRuns[0]
+
+	// Show the run status as a pill
+	statusText := ""
+	var statusColor color.Color
+	bucket := run.Bucket
+	switch bucket {
+	case data.CheckBucketPass:
+		statusText = SuccessIcon + " Success"
+		statusColor = m.styles.colors.successColor
+	case data.CheckBucketFail:
+		statusText = FailureIcon + " Failed"
+		statusColor = m.styles.colors.errorColor
+	case data.CheckBucketCancel:
+		statusText = CanceledIcon + " Cancelled"
+		statusColor = m.styles.colors.faintColor
+	case data.CheckBucketPending:
+		statusText = PendingIcon + " In Progress"
+		statusColor = m.styles.colors.warnColor
+	default:
+		statusText = WaitingIcon + " Pending"
+		statusColor = m.styles.colors.warnColor
+	}
+	status := makePill(statusText,
+		lipgloss.NewStyle().Foreground(m.styles.colors.darkerColor), statusColor)
+
+	repoName := bgStyle.Foreground(m.styles.colors.darkColor).Bold(true).Render(m.repo)
+	runIdText := bgStyle.Foreground(m.styles.colors.faintColor).Render(
+		fmt.Sprintf("run #%s", m.runID))
+
+	topLine := bgStyle.Width(contentWidth).Render(lipgloss.JoinHorizontal(lipgloss.Top,
+		bgStyle.Render(status),
+		bgStyle.Render(" "),
+		repoName,
+		bgStyle.Render(" "),
+		runIdText,
+	))
+
+	bottomLine := bgStyle.Width(contentWidth).Bold(true).Render(run.Name)
+
+	title := bgStyle.Width(contentWidth).Render(lipgloss.JoinVertical(lipgloss.Left,
+		topLine,
+		bottomLine,
+	))
+
+	return m.styles.headerStyle.Width(m.width).Render(
+		lipgloss.JoinHorizontal(lipgloss.Left, bgStyle.Render(title), logo))
+}
+
 func (m *model) viewFooter() string {
 	bg := lipgloss.NewStyle().Background(m.styles.footerStyle.GetBackground())
 	sFooter := m.styles.footerStyle.Width(m.width)
+
+	if m.runID != "" {
+		return m.viewRunModeFooter(bg, sFooter)
+	}
 
 	if m.width == 0 || len(m.prWithChecks.Commits.Nodes) == 0 {
 		return sFooter.Inherit(bg).Render("")
@@ -905,6 +1004,89 @@ func (m *model) viewFooter() string {
 
 	return sFooter.Render(
 		lipgloss.JoinHorizontal(lipgloss.Top, totalText, checks, gap, reFetchingIn, help))
+}
+
+func (m *model) viewRunModeFooter(bg lipgloss.Style, sFooter lipgloss.Style) string {
+	if m.width == 0 || len(m.workflowRuns) == 0 {
+		return sFooter.Inherit(bg).Render("")
+	}
+
+	run := m.workflowRuns[0]
+	texts := make([]string, 0)
+
+	totalJobs := len(run.Jobs)
+	totalText := ""
+	if totalJobs > 0 {
+		totalText = bg.Foreground(m.styles.colors.lightColor).Render(
+			fmt.Sprintf("%d jobs: ", totalJobs))
+	}
+
+	var failed, inProgress, succeeded, skipped int
+	for _, job := range run.Jobs {
+		switch job.Bucket {
+		case data.CheckBucketFail:
+			failed++
+		case data.CheckBucketPending:
+			inProgress++
+		case data.CheckBucketPass:
+			succeeded++
+		case data.CheckBucketSkipping:
+			skipped++
+		}
+	}
+
+	if failed > 0 {
+		texts = append(texts, bg.Foreground(m.styles.colors.errorColor).Render(
+			fmt.Sprintf("%d failing", failed)))
+	}
+	if inProgress > 0 {
+		texts = append(texts, bg.Foreground(m.styles.colors.warnColor).Render(
+			fmt.Sprintf("%d in progress", inProgress)))
+	}
+	if succeeded > 0 {
+		texts = append(texts, bg.Foreground(m.styles.colors.successColor).Render(
+			fmt.Sprintf("%d successful", succeeded)))
+	}
+	if skipped > 0 {
+		texts = append(texts, bg.Foreground(m.styles.colors.faintColor).Render(
+			fmt.Sprintf("%d skipped", skipped)))
+	}
+
+	checksText := bg.Render(strings.Join(texts, bg.Render(", ")))
+
+	reFetchingIn := ""
+	if m.isRunInProgress() {
+		until := time.Until(m.lastFetched.Add(refreshInterval)).Truncate(time.Second).Seconds()
+		untilStr := fmt.Sprintf("in %ds", int(until))
+		if until <= 0 {
+			untilStr = "now..."
+		}
+		reFetchingIn = bg.Padding(0, 1).
+			Foreground(m.styles.colors.faintColor).
+			Render(fmt.Sprintf("refreshing %s", untilStr))
+	}
+
+	help := m.styles.helpButtonStyle.Render("? help")
+
+	gap := bg.Render(
+		strings.Repeat(" ", max(0, m.width-lipgloss.Width(totalText)-lipgloss.Width(checksText)-
+			lipgloss.Width(reFetchingIn)-lipgloss.Width(help)-
+			m.styles.footerStyle.GetHorizontalFrameSize())))
+
+	return sFooter.Render(
+		lipgloss.JoinHorizontal(lipgloss.Top, totalText, checksText, gap, reFetchingIn, help))
+}
+
+func (m *model) isRunInProgress() bool {
+	if len(m.workflowRuns) == 0 {
+		return true
+	}
+	for _, job := range m.workflowRuns[0].Jobs {
+		if job.IsStatusInProgress() {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *model) shouldShowSteps() bool {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -927,11 +927,27 @@ func (m *model) viewRunModeHeader(bgStyle lipgloss.Style, logo string, logoWidth
 		runIdText,
 	))
 
+	// Show PR title and number when the run is against a PR, otherwise show
+	// the run's display title to avoid duplicating the workflow name that
+	// already appears in the run list.
 	titleText := run.DisplayTitle
 	if titleText == "" {
 		titleText = run.Name
 	}
-	bottomLine := bgStyle.Width(contentWidth).Bold(true).Render(titleText)
+
+	var bottomLine string
+	if run.PRNumber > 0 {
+		prLabel := bgStyle.Foreground(m.styles.colors.faintColor).Render(
+			fmt.Sprintf("#%d", run.PRNumber))
+		bottomLine = bgStyle.Width(contentWidth).Render(
+			lipgloss.JoinHorizontal(lipgloss.Top,
+				bgStyle.Bold(true).Render(titleText),
+				bgStyle.Render(" "),
+				prLabel,
+			))
+	} else {
+		bottomLine = bgStyle.Width(contentWidth).Bold(true).Render(titleText)
+	}
 
 	title := bgStyle.Width(contentWidth).Render(lipgloss.JoinVertical(lipgloss.Left,
 		topLine,


### PR DESCRIPTION
## Summary

Adds support for viewing a workflow run directly, without needing a PR:

```bash
# Via URL
gh enhance https://github.com/owner/repo/actions/runs/23687980056

# Via run ID (--run disambiguates from PR numbers)
gh enhance 23687980056 --run
```

### Changes

**`cmd/enhance/root.go`** — URL parsing + CLI
- Detects `/actions/runs/{id}` in URLs alongside existing `/pull/{n}` handling
- Adds `--run` flag for bare numeric IDs
- Updated usage string and examples

**`internal/data/data.go`** — Data model
- Added `DisplayTitle` field to `WorkflowRun` struct (used to show PR title for PR-triggered runs instead of duplicating the workflow name)

**`internal/tui/tui.go`** — Model + views
- Added `runID` field and `RunID` to `ModelOpts`
- `Init()` branches to run mode when `runID` is set
- `viewRunModeHeader()`: shows run status pill, repo ⋅ run ID, and display title
- Refactored footer: `appendStatTexts()` and `renderFooterLayout()` are shared between PR and run mode footers, eliminating duplication
- `isRunModeInProgress()`: checks whether the run is still in progress
- Handles `runModeFetchedMsg` and `runModeIntervalTickMsg` in `Update()`

**`internal/tui/cmds.go`** — Data fetching
- `startSpinners()`: extracted shared spinner init (reused by both `makeInitCmd` and `makeRunModeInitCmd`)
- `makeRunModeInitCmd()`: alternate init path using REST API
- `fetchRun()`: fetches run + jobs via `FetchWorkflowRunByID`/`FetchWorkflowRunJobs`
- `fetchRunWithInterval()`: polls until run completes (with rate limit guard)
- `convertRunResponseToWorkflowRun()`: maps REST responses to existing `data.WorkflowRun`/`WorkflowJob` types

### What stays unchanged

The core TUI components — job list, step list, log viewer, rerun actions, and all delegates — work without modification. Run mode maps REST data into the same types they already consume.

### Testing

- `go build ./...` ✅
- `golangci-lint` ✅
- `go test ./...` ✅

Closes #19

Demo:

![run-mode-demo](https://github.com/user-attachments/assets/1cc1d3d7-c819-4372-969e-2b96ff610f83)
