### PR TITLE
feat: bind q to quit outside text inputs

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -15,7 +15,14 @@ var (
 
 	quitKey = key.NewBinding(
 		key.WithKeys("ctrl+c"),
-		key.WithHelp("ctrl+c", "quit"),
+		key.WithHelp("q/ctrl+c", "quit"),
+	)
+
+	// Matched after the filter/search input guards so typing "q" into an
+	// input still works; ctrl+c (quitKey) quits from anywhere.
+	softQuitKey = key.NewBinding(
+		key.WithKeys("q"),
+		key.WithHelp("q", "quit"),
 	)
 
 	nextRowKey = key.NewBinding(

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -477,6 +477,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		if key.Matches(msg, softQuitKey) {
+			log.Info("quitting", "msg", msg)
+			return m, tea.Quit
+		}
+
 		if key.Matches(msg, modeKey) {
 			// TODO: block if we're in repo mode
 			m.flat = !m.flat


### PR DESCRIPTION
gh-dash quits on `q`, Enhance only on `ctrl+c` — this adds `q` for parity and muscle memory.

`q` couldn't just be added to `quitKey`: that's matched before the list-filter and log-search guards, so it would quit while typing a "q" into an input. Instead `q` is a separate binding matched right after those guards; `ctrl+c` is unchanged and still quits from anywhere. Help text now reads `q/ctrl+c quit`.

**AI disclosure** (per AI_POLICY.md): implemented with Claude Code; I reviewed the diff and tested the behavior manually myself.